### PR TITLE
Fetch and Display Builder Count from BatchRegistry Contract

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -30,7 +30,7 @@ const Home: NextPage = () => {
               <p>Error fetching contract data: {error.message}</p>
             </div>
           ) : (
-            <p className="text-lg flex gap-2 justify-center">
+            <div className="text-lg flex gap-2 justify-center">
               <span className="font-bold">Checked in builders count:</span>
               {contractLoading ? (
                 <span className="animate-pulse">
@@ -39,7 +39,7 @@ const Home: NextPage = () => {
               ) : (
                 <span>{checkedInCounter !== undefined ? Number(checkedInCounter) : "0"}</span>
               )}
-            </p>
+            </div>
           )}
         </div>
 

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -15,32 +15,6 @@ const Home: NextPage = () => {
     functionName: "checkedInCounter",
   });
 
-  const renderCheckedInCounterSection = () => {
-    if (contractLoading) {
-      return (
-        <div className="animate-pulse">
-          <div className="h-6 bg-gray-200 rounded w-48 mb-4"></div>
-          <div className="h-4 bg-gray-200 rounded w-24"></div>
-        </div>
-      );
-    }
-
-    if (error) {
-      return (
-        <div className="p-4 rounded-lg bg-red-100 text-red-700" role="alert">
-          <p>Error fetching contract data: {error.message}</p>
-        </div>
-      );
-    }
-
-    return (
-      <p className="text-lg flex gap-2 justify-center">
-        <span className="font-bold">Checked in builders count:</span>
-        <span>{checkedInCounter !== undefined ? Number(checkedInCounter) : "0"}</span>
-      </p>
-    );
-  };
-
   return (
     <>
       <div className="flex items-center flex-col flex-grow pt-10">
@@ -50,7 +24,23 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Batch 10</span>
           </h1>
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
-          {renderCheckedInCounterSection()}
+
+          {error ? (
+            <div className="p-4 rounded-lg bg-red-100 text-red-700" role="alert">
+              <p>Error fetching contract data: {error.message}</p>
+            </div>
+          ) : (
+            <p className="text-lg flex gap-2 justify-center">
+              <span className="font-bold">Checked in builders count:</span>
+              {contractLoading ? (
+                <span className="animate-pulse">
+                  <div className="h-6 bg-gray-200 rounded w-12"></div>
+                </span>
+              ) : (
+                <span>{checkedInCounter !== undefined ? Number(checkedInCounter) : "0"}</span>
+              )}
+            </p>
+          )}
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,16 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
-  const [counter, setCounter] = useState<number | undefined>();
-
   const {
-    data,
+    data: checkedInCounter,
     error,
     isLoading: contractLoading,
   } = useScaffoldReadContract({
@@ -18,13 +15,16 @@ const Home: NextPage = () => {
     functionName: "checkedInCounter",
   });
 
-  useEffect(() => {
-    if (data !== undefined) {
-      setCounter(Number(data));
+  const renderCheckedInCounterSection = () => {
+    if (contractLoading) {
+      return (
+        <div className="animate-pulse">
+          <div className="h-6 bg-gray-200 rounded w-48 mb-4"></div>
+          <div className="h-4 bg-gray-200 rounded w-24"></div>
+        </div>
+      );
     }
-  }, [data]);
 
-  const renderContent = () => {
     if (error) {
       return (
         <div className="p-4 rounded-lg bg-red-100 text-red-700" role="alert">
@@ -36,56 +36,10 @@ const Home: NextPage = () => {
     return (
       <p className="text-lg flex gap-2 justify-center">
         <span className="font-bold">Checked in builders count:</span>
-        <span>{counter !== undefined ? counter : "0"}</span>
+        <span>{checkedInCounter !== undefined ? Number(checkedInCounter) : "0"}</span>
       </p>
     );
   };
-
-  if (contractLoading) {
-    return (
-      <div className="w-full h-full mt-20 animate-pulse">
-        <div className="mb-6 flex items-center">
-          <div className="w-10 h-10 bg-gray-200 rounded-full mr-4"></div>
-          <div>
-            <div className="h-4 bg-gray-200 rounded w-24 mb-2"></div>
-            <div className="h-6 bg-gray-200 rounded w-48"></div>
-          </div>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-8">
-          <div className="bg-gray-200 rounded-lg h-96"></div>
-
-          <div>
-            <div className="h-8 bg-gray-200 rounded w-3/4 mb-4"></div>
-            <div className="space-y-2 mb-6">
-              {[...Array(6)].map((_, index) => (
-                <div key={index} className="h-4 bg-gray-200 rounded w-full"></div>
-              ))}
-            </div>
-
-            <div className="flex items-center mb-4">
-              <div className="h-8 bg-gray-200 rounded w-24 mr-4"></div>
-              <div className="h-8 bg-gray-200 rounded-full w-8"></div>
-              <div className="h-6 bg-gray-200 rounded w-8 mx-4"></div>
-              <div className="h-8 bg-gray-200 rounded-full w-8"></div>
-            </div>
-
-            <div className="flex space-x-4 mb-6">
-              <div className="h-10 bg-gray-200 rounded w-2/3"></div>
-              <div className="h-10 bg-gray-200 rounded w-1/3"></div>
-            </div>
-
-            <div>
-              <div className="h-6 bg-gray-200 rounded w-24 mb-2"></div>
-              <div className="h-4 bg-gray-200 rounded w-full mb-2"></div>
-              <div className="h-4 bg-gray-200 rounded w-full mb-2"></div>
-              <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <>
@@ -96,7 +50,7 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Batch 10</span>
           </h1>
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
-          {renderContent()}
+          {renderCheckedInCounterSection()}
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,10 +1,92 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const [counter, setCounter] = useState<number | undefined>();
+
+  const {
+    data,
+    error,
+    isLoading: contractLoading,
+  } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
+  useEffect(() => {
+    if (data !== undefined) {
+      setCounter(Number(data));
+    }
+  }, [data]);
+
+  const renderContent = () => {
+    if (error) {
+      return (
+        <div className="p-4 rounded-lg bg-red-100 text-red-700" role="alert">
+          <p>Error fetching contract data: {error.message}</p>
+        </div>
+      );
+    }
+
+    return (
+      <p className="text-lg flex gap-2 justify-center">
+        <span className="font-bold">Checked in builders count:</span>
+        <span>{counter !== undefined ? counter : "0"}</span>
+      </p>
+    );
+  };
+
+  if (contractLoading) {
+    return (
+      <div className="w-full h-full mt-20 animate-pulse">
+        <div className="mb-6 flex items-center">
+          <div className="w-10 h-10 bg-gray-200 rounded-full mr-4"></div>
+          <div>
+            <div className="h-4 bg-gray-200 rounded w-24 mb-2"></div>
+            <div className="h-6 bg-gray-200 rounded w-48"></div>
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-8">
+          <div className="bg-gray-200 rounded-lg h-96"></div>
+
+          <div>
+            <div className="h-8 bg-gray-200 rounded w-3/4 mb-4"></div>
+            <div className="space-y-2 mb-6">
+              {[...Array(6)].map((_, index) => (
+                <div key={index} className="h-4 bg-gray-200 rounded w-full"></div>
+              ))}
+            </div>
+
+            <div className="flex items-center mb-4">
+              <div className="h-8 bg-gray-200 rounded w-24 mr-4"></div>
+              <div className="h-8 bg-gray-200 rounded-full w-8"></div>
+              <div className="h-6 bg-gray-200 rounded w-8 mx-4"></div>
+              <div className="h-8 bg-gray-200 rounded-full w-8"></div>
+            </div>
+
+            <div className="flex space-x-4 mb-6">
+              <div className="h-10 bg-gray-200 rounded w-2/3"></div>
+              <div className="h-10 bg-gray-200 rounded w-1/3"></div>
+            </div>
+
+            <div>
+              <div className="h-6 bg-gray-200 rounded w-24 mb-2"></div>
+              <div className="h-4 bg-gray-200 rounded w-full mb-2"></div>
+              <div className="h-4 bg-gray-200 rounded w-full mb-2"></div>
+              <div className="h-4 bg-gray-200 rounded w-3/4"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <div className="flex items-center flex-col flex-grow pt-10">
@@ -14,10 +96,7 @@ const Home: NextPage = () => {
             <span className="block text-4xl font-bold">Batch 10</span>
           </h1>
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
-          <p className="text-lg flex gap-2 justify-center">
-            <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
-          </p>
+          {renderContent()}
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">


### PR DESCRIPTION
## Description

This pull request addresses the display of the number of builders who have checked into the contract within the `packages/nextjs/app/page.tsx` file. Currently, a placeholder string "To Be implemented" is displayed, which does not provide any useful information to users. 

<img width="1393" alt="Screenshot 2024-10-18 at 10 51 47 PM" src="https://github.com/user-attachments/assets/94a53217-e764-4277-8a47-8164be466b79">



### Proposed Changes
- Replace the placeholder string with the actual count of builders who have checked in, which will be retrieved from the `BatchRegistry` contract.
- Implement a method to fetch this count and ensure it updates dynamically when the data changes.

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)


_Closes #5


Address:0x62CeF3Ca8b52a9C69a17236CA2c56Cdb7a383E8e
