### PR TITLE
#9 personal page

### DIFF
--- a/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/components/Socials.tsx
+++ b/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/components/Socials.tsx
@@ -1,0 +1,31 @@
+import { FaLinkedin, FaXTwitter } from "react-icons/fa6";
+import { MdEmail } from "react-icons/md";
+
+const contactLinks = [
+  {
+    link: "mailto:michael.esenwa@yahoo.com",
+    image: <MdEmail size={24} />,
+  },
+  {
+    link: "https://twitter.com/kcmikee",
+    image: <FaXTwitter size={24} />,
+  },
+  {
+    link: "https://www.linkedin.com/in/kachukwu-michael-esenwa/",
+    image: <FaLinkedin size={24} />,
+  },
+];
+
+const Socials = () => {
+  return (
+    <div className="flex items-center gap-3">
+      {contactLinks.map((_, i) => (
+        <a key={i} href={_.link} target="_blank">
+          {_.image}
+        </a>
+      ))}
+    </div>
+  );
+};
+
+export default Socials;

--- a/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
+++ b/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
@@ -45,7 +45,7 @@ const MichaelEsenwa: NextPage = () => {
           </div>
 
           <div className="mt-4">
-            <h4 className="">Address: 0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441</h4>
+            <p className="text-xs md:text-base">Address: 0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441</p>
             <h4 className="mt-8">📫 How to reach me:</h4>
             <div className="flex items-center gap-3">
               {contactLink.map((_, i) => (

--- a/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
+++ b/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import Image from "next/image";
+import { NextPage } from "next";
+
+const MichaelEsenwa: NextPage = () => {
+  const contactLink = [
+    {
+      link: "https://wa.me/2347081293274?text=Hello Michael",
+      image: "https://img.shields.io/badge/WHATSAPP-%2325D366.svg?&style=for-the-badge&logo=whatsapp&logoColor=white",
+      title: "Whatsapp",
+    },
+    {
+      link: "mailto:michael.esenwa@yahoo.com",
+      image: "https://img.shields.io/badge/email me-%23D14836.svg?&style=for-the-badge&logo=gmail&logoColor=white",
+      title: "Email",
+    },
+    {
+      link: "https://twitter.com/kcmikee",
+      image: "https://img.shields.io/badge/twitter-%231DA1F2.svg?&style=for-the-badge&logo=twitter&logoColor=white",
+      title: "Twitter",
+    },
+    {
+      link: "https://www.linkedin.com/in/kachukwu-michael-esenwa/",
+      image: "https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white",
+      title: "LinkedIn",
+    },
+  ];
+  return (
+    <div className="flex flex-col items-center h-[80vh] pt-20 md:pt-0 md:justify-center bg-gradient-to-br from-gray-800 to-base-300">
+      <div className="flex justify-between w-11/12 p-4 border border-gray-600 rounded-md md:p-8 md:w-9/12">
+        <div className="">
+          <div className="flex justify-between">
+            <h1 className="text-2xl font-bold lg:text-4xl text-start">Hi there, I am Kachukwu Michael Esenwa </h1>
+            <div className="h-[100px] w-[100px] lg:w-[300px] lg:h-[300px] shrink-0 !overflow-hidden rounded-full relative lg:hidden">
+              <Image fill src="https://avatars.githubusercontent.com/u/42065630?v=4" alt="avatar" />
+            </div>
+          </div>
+          <hr className="mt-2 border-gray-500" />
+          <div className="flex justify-between">
+            <h4 className="mt-5 text-base text-start">
+              I am a Front End Developer with a strong emphasis on creating high-performance web applications. With over
+              four years in the industry, my expertise lies in writing clean, efficient code and optimizing web pages
+              for speed and scalability. 💻
+            </h4>
+          </div>
+
+          <div className="mt-4">
+            <h4>📫 How to reach me:</h4>
+            <div className="flex items-center gap-3">
+              {contactLink.map((_, i) => (
+                <>
+                  <a key={i} href={_.link} target="_blank">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img alt={_.title} src={_.image} />
+                  </a>
+                </>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="h-[100px] w-[100px] lg:w-[300px] lg:h-[300px] shrink-0 !overflow-hidden rounded-full relative hidden lg:block">
+          <Image fill src="https://avatars.githubusercontent.com/u/42065630?v=4" alt="avatar" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MichaelEsenwa;

--- a/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
+++ b/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
@@ -45,7 +45,8 @@ const MichaelEsenwa: NextPage = () => {
           </div>
 
           <div className="mt-4">
-            <h4>📫 How to reach me:</h4>
+            <h4 className="">Address: 0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441</h4>
+            <h4 className="mt-8">📫 How to reach me:</h4>
             <div className="flex items-center gap-3">
               {contactLink.map((_, i) => (
                 <>

--- a/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
+++ b/packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx
@@ -1,36 +1,17 @@
-import React from "react";
 import Image from "next/image";
+import Socials from "./components/Socials";
 import { NextPage } from "next";
+import { Address } from "~~/components/scaffold-eth";
 
 const MichaelEsenwa: NextPage = () => {
-  const contactLink = [
-    {
-      link: "https://wa.me/2347081293274?text=Hello Michael",
-      image: "https://img.shields.io/badge/WHATSAPP-%2325D366.svg?&style=for-the-badge&logo=whatsapp&logoColor=white",
-      title: "Whatsapp",
-    },
-    {
-      link: "mailto:michael.esenwa@yahoo.com",
-      image: "https://img.shields.io/badge/email me-%23D14836.svg?&style=for-the-badge&logo=gmail&logoColor=white",
-      title: "Email",
-    },
-    {
-      link: "https://twitter.com/kcmikee",
-      image: "https://img.shields.io/badge/twitter-%231DA1F2.svg?&style=for-the-badge&logo=twitter&logoColor=white",
-      title: "Twitter",
-    },
-    {
-      link: "https://www.linkedin.com/in/kachukwu-michael-esenwa/",
-      image: "https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white",
-      title: "LinkedIn",
-    },
-  ];
   return (
-    <div className="flex flex-col items-center h-[80vh] pt-20 md:pt-0 md:justify-center bg-gradient-to-br from-gray-800 to-base-300">
-      <div className="flex justify-between w-11/12 p-4 border border-gray-600 rounded-md md:p-8 md:w-9/12">
+    <div className="flex flex-col items-center h-[80vh] pt-20 md:pt-0 md:justify-center bg-white dark:bg-gradient-to-br dark:from-gray-800 dark:to-base-300">
+      <div className="flex justify-between w-11/12 p-4 border border-gray-200 rounded-lg shadow-sm dark:border-gray-600 md:p-8 md:w-9/12">
         <div className="">
           <div className="flex justify-between">
-            <h1 className="text-2xl font-bold lg:text-4xl text-start">Hi there, I am Kachukwu Michael Esenwa </h1>
+            <h1 className="text-2xl font-bold lg:text-4xl text-start dark:text-white">
+              Hi there, I am Kachukwu Michael Esenwa{" "}
+            </h1>
             <div className="h-[100px] w-[100px] lg:w-[300px] lg:h-[300px] shrink-0 !overflow-hidden rounded-full relative lg:hidden">
               <Image fill src="https://avatars.githubusercontent.com/u/42065630?v=4" alt="avatar" />
             </div>
@@ -45,18 +26,19 @@ const MichaelEsenwa: NextPage = () => {
           </div>
 
           <div className="mt-4">
-            <p className="text-xs md:text-base">Address: 0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441</p>
-            <h4 className="mt-8">📫 How to reach me:</h4>
-            <div className="flex items-center gap-3">
-              {contactLink.map((_, i) => (
-                <>
-                  <a key={i} href={_.link} target="_blank">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img alt={_.title} src={_.image} />
-                  </a>
-                </>
-              ))}
+            <div className="text-xs md:text-base">
+              Address:{" "}
+              <div className="block mt-1.5">
+                <Address
+                  onlyEnsOrAddress
+                  address="0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441"
+                  format="short"
+                  size="sm"
+                />
+              </div>
             </div>
+            <h4 className="mt-8">📫 How to reach me:</h4>
+            <Socials />
           </div>
         </div>
         <div className="h-[100px] w-[100px] lg:w-[300px] lg:h-[300px] shrink-0 !overflow-hidden rounded-full relative hidden lg:block">


### PR DESCRIPTION
## Description

feat: Add builder profile page for 0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441

Added a new personal builder page with the following components:
- Personal biography
- Profile avatar
- Social media integration links

The implementation follows the existing page structure under packages/nextjs/app/builders/ and complies with project linting standards.

Location: packages/nextjs/app/builders/0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441/page.tsx

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

Your ENS/address: 0x8Bb563DC969cC3b3e7275474c3847b44dBCB9441

<img width="1439" alt="Screenshot 2024-10-31 at 3 04 01 AM" src="https://github.com/user-attachments/assets/3d0fdb2e-905f-4e70-a004-5fba0bec75ca">
